### PR TITLE
Updates bech32 checksum constant to "M"

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,19 @@ public class EncodingExample {
 
     public static void main(String[] args) {
 
-            // simple human readable part with data part
-            String humanReadablePart = "hello";
-            char[] data = {14, 15, 3, 31, 13};
-            String b = Bech32.encode(humanReadablePart, data);
+        // simple human readable part with data part
+        String humanReadablePart = "hello";
+        char[] data = {14, 15, 3, 31, 13};
+        String b = Bech32.encode(humanReadablePart, data);
 
-            System.out.println(b);
-            // prints "hello1w0rldjn365x" : "hello" + Bech32.SEPARATOR + encoded data + 6 char checksum
+        System.out.println(b);
+        // prints "hello1w0rldjn365x" : "hello" + Bech32.SEPARATOR + encoded data + 6 char checksum
+
+        HrpAndDp hd = Bech32.decode(b);
+
+        assert hd.getHrp().equals("hello");
+        assert hd.getDp().length == 5;
+        assert hd.getEncoding() == HrpAndDp.Encoding.BECH32M;
     }
 }
 ```
@@ -60,6 +66,31 @@ You can also run just the tests without installing:
 
 ```console
 mvn test
+```
+
+## Regarding bech32 checksums
+
+The Bech32 data encoding format was first proposed by Pieter Wuille in early 2017 in
+[BIP 0173](https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki). Later, in November 2019, Pieter published
+some research regarding that an exponent used in the bech32 checksum algorithm (value = 1) may not be
+optimal for the error detecting properties of bech32. In February 2021, Pieter published
+[BIP 0350](http://www.example.com) reporting that "exhaustive analysis" showed the best possible exponent value is
+0x2bc830a3. This improved variant of Bech32 is called "Bech32m".
+
+When decoding a possible bech32 encoded string, libbech32 returns an enum value showing whether bech32m or bech32
+was used to encode. This can be seen in the example above.
+
+When encoding data, libbech32 defaults to using the new exponent value of 0x2bc830a3. If the original exponent value
+of 1 is desired, then the following functions may be used:
+
+### Usage Example
+
+```java
+    /// ... as above ...
+
+    String b = Bech32.encodeUsingOriginalConstant(humanReadablePart, data);
+
+    /// ... as above ...
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To use the package, you need the following Maven dependency:
 <dependency>
   <groupId>design.contract</groupId>
   <artifactId>libbech32</artifactId>
-  <version>1.0.0</version>
+  <version>1.1.0</version>
 </dependency>
 ```
 
@@ -38,7 +38,7 @@ public class EncodingExample {
             String b = Bech32.encode(humanReadablePart, data);
 
             System.out.println(b);
-            // prints "hello1w0rldcs7fw6" : "hello" + Bech32.separator + encoded data + 6 char checksum
+            // prints "hello1w0rldjn365x" : "hello" + Bech32.SEPARATOR + encoded data + 6 char checksum
     }
 }
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>design.contract</groupId>
     <artifactId>libbech32</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
 
     <packaging>jar</packaging>
 

--- a/src/main/java/design/contract/bech32/Bech32.java
+++ b/src/main/java/design/contract/bech32/Bech32.java
@@ -2,48 +2,52 @@ package design.contract.bech32;
 
 import java.util.Arrays;
 import java.util.Objects;
+import java.util.function.BiFunction;
 
-public interface Bech32 {
+public class Bech32 {
 
-    interface limits {
+    public static final class Limits {
 
         // size of the set of character values which are valid for a bech32 string
-        int VALID_CHARSET_SIZE = 32;
+        public static final int VALID_CHARSET_SIZE = 32;
 
         // size of the set of "reverse" character values used for decoding
-        int REVERSE_CHARSET_SIZE = 128;
+        public static final int REVERSE_CHARSET_SIZE = 128;
 
         // while there are only 32 valid character values in a bech32 string, other characters
         // can be present but will be stripped out. however, all character values must fall
         // within the following range.
-        int MIN_BECH32_CHAR_VALUE = 33;  // ascii '!'
-        int MAX_BECH32_CHAR_VALUE = 126; // ascii '~'
+        public static final int MIN_BECH32_CHAR_VALUE = 33;  // ascii '!'
+        public static final int MAX_BECH32_CHAR_VALUE = 126; // ascii '~'
 
         // human-readable part of a bech32 string can only be between 1 and 83 characters long
-        int MIN_HRP_LENGTH = 1;
-        int MAX_HRP_LENGTH = 83;
+        public static final int MIN_HRP_LENGTH = 1;
+        public static final int MAX_HRP_LENGTH = 83;
 
         // checksum is always 6 chars long
-        int CHECKSUM_LENGTH = 6;
+        public static final int CHECKSUM_LENGTH = 6;
 
         // entire bech32 string can only be a certain size (after invalid characters are stripped out)
-        int MIN_BECH32_LENGTH = 8;  // MIN_HRP_LENGTH + '1' + CHECKSUM_LENGTH
-        int MAX_BECH32_LENGTH = 90; // MAX_HRP_LENGTH + '1' + CHECKSUM_LENGTH
+        public static final int MIN_BECH32_LENGTH = 8;  // MIN_HRP_LENGTH + '1' + CHECKSUM_LENGTH
+        public static final int MAX_BECH32_LENGTH = 90; // MAX_HRP_LENGTH + '1' + CHECKSUM_LENGTH
 
+        private Limits() {
+            throw new IllegalStateException("should not instantiate");
+        }
     }
 
-    interface impl {
+    public static final class Impl {
 
         // bech32 string must be at least 8 chars long: HRP (min 1 char) + '1' + 6-char checksum
         static void rejectBStringTooShort(final String bstring) {
-            if (bstring.length() < limits.MIN_BECH32_LENGTH)
-                throw new RuntimeException("bech32 string too short");
+            if (bstring.length() < Limits.MIN_BECH32_LENGTH)
+                throw new IllegalArgumentException("bech32 string too short");
         }
 
         // bech32 string can be at most 90 characters long
         static void rejectBStringTooLong(final String bstring) {
-            if (bstring.length() > limits.MAX_BECH32_LENGTH)
-                throw new RuntimeException("bech32 string too long");
+            if (bstring.length() > Limits.MAX_BECH32_LENGTH)
+                throw new IllegalArgumentException("bech32 string too long");
         }
 
         // bech32 string can not mix upper and lower case
@@ -53,23 +57,23 @@ public interface Bech32 {
             boolean atLeastOneLower = bstring.chars()
                     .anyMatch(Character::isLowerCase);
             if(atLeastOneUpper && atLeastOneLower) {
-                throw new RuntimeException("bech32 string is mixed case");
+                throw new IllegalArgumentException("bech32 string is mixed case");
             }
         }
 
         // bech32 string values must be in range ASCII 33-126
         static void rejectBStringValuesOutOfRange(final String bstring) {
             boolean atLeastOneOutOfRange = bstring.chars()
-                    .anyMatch(c -> (c < limits.MIN_BECH32_CHAR_VALUE || c > limits.MAX_BECH32_CHAR_VALUE));
+                    .anyMatch(c -> (c < Limits.MIN_BECH32_CHAR_VALUE || c > Limits.MAX_BECH32_CHAR_VALUE));
             if(atLeastOneOutOfRange) {
-                throw new RuntimeException("bech32 string has value out of range");
+                throw new IllegalArgumentException("bech32 string has value out of range");
             }
         }
 
         // bech32 string must contain the separator character
         static void rejectBStringWithNoSeparator(final String bstring) {
-            if(bstring.chars().noneMatch(c -> (c == separator))) {
-                throw new RuntimeException("bech32 string is missing separator character");
+            if(bstring.chars().noneMatch(c -> (c == SEPARATOR))) {
+                throw new IllegalArgumentException("bech32 string is missing separator character");
             }
         }
 
@@ -84,7 +88,7 @@ public interface Bech32 {
 
         // return the position of the separator character
         static int findSeparatorPosition(final String bstring) {
-            return bstring.lastIndexOf(separator);
+            return bstring.lastIndexOf(SEPARATOR);
         }
 
         // split the hrp from the dp at the separator character
@@ -99,11 +103,11 @@ public interface Bech32 {
         static void mapDP(char[] dp) {
             for (int i = 0, dpLength = dp.length; i < dpLength; i++) {
                 char c = dp[i];
-                if (c > limits.REVERSE_CHARSET_SIZE - 1)
-                    throw new RuntimeException("data part contains character value out of range");
-                int d = charset_rev[c];
+                if (c > Limits.REVERSE_CHARSET_SIZE - 1)
+                    throw new IllegalArgumentException("data part contains character value out of range");
+                int d = REVERSE_CHARSET[c];
                 if (d == -1)
-                    throw new RuntimeException("data part contains invalid character");
+                    throw new IllegalArgumentException("data part contains invalid character");
                 dp[i] = (char) d;
             }
         }
@@ -150,48 +154,70 @@ public interface Bech32 {
         }
 
         // verify the checksum on a Bech32 string
+        static boolean verifyChecksumBasis(final String hrp, final char[] dp, final int constant) {
+            return polymod(cat(expandHrp(hrp).toCharArray(), dp)) == constant;
+        }
+
+        // verify the checksum on a Bech32 string
         static boolean verifyChecksum(final String hrp, final char[] dp) {
-            return polymod(cat(expandHrp(hrp).toCharArray(), dp)) == M;
+            return verifyChecksumBasis(hrp, dp, M);
+        }
+
+        // verify the checksum on a Bech32 string. This variant of verifyChecksum() uses the
+        // constant "1" instead of "M"
+        static boolean verifyChecksumUsingOriginalConstant(final String hrp, final char[] dp) {
+            return verifyChecksumBasis(hrp, dp, 1);
         }
 
         // strip off the checksum from a Bech32 string
         static String stripChecksum(final String dp) {
-            return dp.substring(0, dp.length() - limits.CHECKSUM_LENGTH);
+            return dp.substring(0, dp.length() - Limits.CHECKSUM_LENGTH);
         }
 
         // create a checksum for a given HRP and a DP array
-        static String createChecksum(final String hrp, final char[] dp) {
+        static String createChecksumBasis(final String hrp, final char[] dp, final int constant) {
             char[] combined = cat(expandHrp(hrp).toCharArray(), dp);
-            char[] expanded = Arrays.copyOf(combined, combined.length + limits.CHECKSUM_LENGTH);
+            char[] expanded = Arrays.copyOf(combined, combined.length + Limits.CHECKSUM_LENGTH);
 
-            long mod = polymod(expanded) ^ M;
-            char[] ret = new char[limits.CHECKSUM_LENGTH];
-            for(int i = 0; i < limits.CHECKSUM_LENGTH; ++i) {
+            long mod = polymod(expanded) ^ constant;
+            char[] ret = new char[Limits.CHECKSUM_LENGTH];
+            for(int i = 0; i < Limits.CHECKSUM_LENGTH; ++i) {
                 ret[i] = (char)((mod >> (5 * (5 - i))) & 31);
             }
             return new String(ret);
         }
 
+        // create a checksum for a given HRP and a DP array
+        static String createChecksum(final String hrp, final char[] dp) {
+            return createChecksumBasis(hrp, dp, M);
+        }
+
+        // create a checksum for a given HRP and a DP array. This variant of createChecksum() uses the
+        // constant "1" instead of "M"
+        static String createChecksumUsingOriginalConstant(final String hrp, final char[] dp) {
+            return createChecksumBasis(hrp, dp, 1);
+        }
+
         static void rejectHRPTooShort(final String hrp) {
-            if(hrp.length() < limits.MIN_HRP_LENGTH)
-                throw new RuntimeException("HRP must be at least one character");
+            if(hrp.length() < Limits.MIN_HRP_LENGTH)
+                throw new IllegalArgumentException("HRP must be at least one character");
         }
 
         static void rejectHRPTooLong(final String hrp) {
-            if(hrp.length() > limits.MAX_HRP_LENGTH)
-                throw new RuntimeException("HRP must be less than 84 characters");
+            if(hrp.length() > Limits.MAX_HRP_LENGTH)
+                throw new IllegalArgumentException("HRP must be less than 84 characters");
         }
 
         static void rejectDPTooShort(final char [] dp) {
-            if(dp.length < limits.CHECKSUM_LENGTH)
-                throw new RuntimeException("data part must be at least six characters");
+            if(dp.length < Limits.CHECKSUM_LENGTH)
+                throw new IllegalArgumentException("data part must be at least six characters");
         }
 
         // data values must be in range ASCII 0-31 in order to index into the charset
         static void rejectDataValuesOutOfRange(final char[] dp) {
             for(char c : dp) {
-                if(c > limits.VALID_CHARSET_SIZE-1) {
-                    throw new RuntimeException("data value is out of range");
+                if(c > Limits.VALID_CHARSET_SIZE-1) {
+                    throw new IllegalArgumentException("data value is out of range");
                 }
             }
         }
@@ -199,31 +225,34 @@ public interface Bech32 {
         // length of human part plus length of data part plus separator char plus 6 char
         // checksum must be less than 90
         static void rejectBothPartsTooLong(final String hrp, final char[] dp) {
-            if(hrp.length() + dp.length + 1 + limits.CHECKSUM_LENGTH > limits.MAX_BECH32_LENGTH) {
-                throw new RuntimeException("length of hrp + length of dp is too large");
+            if(hrp.length() + dp.length + 1 + Limits.CHECKSUM_LENGTH > Limits.MAX_BECH32_LENGTH) {
+                throw new IllegalArgumentException("length of hrp + length of dp is too large");
             }
         }
 
+        private Impl() {
+            throw new IllegalStateException("should not instantiate");
+        }
     }
 
     // The Bech32 separator character
-    char separator = '1';
+    static final char SEPARATOR = '1';
 
     // exponent used in checksum generation, taken from recommendation
-    // in: https://gist.github.com/sipa/a9845b37c1b298a7301c33a04090b2eb
-    int M = 0x3FFFFFFF;
+    // in: https://github.com/sipa/bips/blob/bip-bech32m/bip-bech32m.mediawiki
+    static final int M = 0x2bc830a3;
 
     /* The Bech32 character set for encoding. The index into this string gives the char
      * each value is mapped to, i.e., 0 -> 'q', 10 -> '2', etc. This comes from the table
      * in BIP-0173 */
-    String charset = "qpzry9x8gf2tvdw0s3jn54khce6mua7l";
+    static final String CHARSET = "qpzry9x8gf2tvdw0s3jn54khce6mua7l";
 
     /* The Bech32 character set for decoding. This comes from the table in BIP-0173
      *
      * This will help map both upper and lowercase chars into the proper code (or index
      * into the above charset). For instance, 'Q' (ascii 81) and 'q' (ascii 113)
      * are both set to index 0 in this table. Invalid chars are set to -1 */
-    int[] charset_rev = {
+    static final int[] REVERSE_CHARSET = {
             -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
             -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
             -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
@@ -245,7 +274,7 @@ public interface Bech32 {
 
     // clean a bech32 string of any stray characters not in the allowed charset, except for
     // the separator character, which is '1'
-    static String stripUnknownChars(String bstring) {
+    public static String stripUnknownChars(String bstring) {
         if(bstring == null) {
             return null;
         }
@@ -253,7 +282,7 @@ public interface Bech32 {
         StringBuilder result = new StringBuilder(bstring.length());
 
         for(char c : bstring.toCharArray()) {
-            if(c == separator || charset.indexOf(toLowercase(c)) != -1) {
+            if(c == SEPARATOR || CHARSET.indexOf(toLowercase(c)) != -1) {
                 result.append(c);
             }
         }
@@ -262,52 +291,69 @@ public interface Bech32 {
     }
 
     // encode a "human-readable part" and a "data part", returning a bech32 string
-    static String encode(final String hrp, char[] dp) {
+    private static String encodeBasis(final String hrp, char[] dp, BiFunction<String, char[], String> createChecksumFunc) {
         Objects.requireNonNull(hrp);
         Objects.requireNonNull(dp);
 
-        Bech32.impl.rejectHRPTooShort(hrp);
-        Bech32.impl.rejectHRPTooLong(hrp);
-        Bech32.impl.rejectBothPartsTooLong(hrp, dp);
-        Bech32.impl.rejectDataValuesOutOfRange(dp);
+        Impl.rejectHRPTooShort(hrp);
+        Impl.rejectHRPTooLong(hrp);
+        Impl.rejectBothPartsTooLong(hrp, dp);
+        Impl.rejectDataValuesOutOfRange(dp);
 
         String hrpCopy = hrp.toLowerCase();
-        String checksum = Bech32.impl.createChecksum(hrpCopy, dp);
-        char[] combined = Bech32.impl.cat(dp, checksum.toCharArray());
+        String checksum = createChecksumFunc.apply(hrpCopy, dp);
+        char[] combined = Impl.cat(dp, checksum.toCharArray());
 
         StringBuilder result = new StringBuilder(hrpCopy.length() + 1 + combined.length);
         result.append(hrpCopy);
         result.append('1');
 
         for (char c : combined) {
-            if(c > Bech32.limits.VALID_CHARSET_SIZE - 1)
-                throw new RuntimeException("data part contains invalid character");
-            result.append(charset.charAt(c));
+            if(c > Limits.VALID_CHARSET_SIZE - 1)
+                throw new IllegalArgumentException("data part contains invalid character");
+            result.append(CHARSET.charAt(c));
         }
         return result.toString();
+    }
 
+    // encode a "human-readable part" and a "data part", returning a bech32 string
+    public static String encode(final String hrp, char[] dp) {
+        return encodeBasis(hrp, dp, Impl::createChecksum);
+    }
+
+    // encode a "human-readable part" and a "data part", returning a bech32 string
+    public static String encodeUsingOriginalConstant(final String hrp, char[] dp) {
+        return encodeBasis(hrp, dp, Impl::createChecksumUsingOriginalConstant);
     }
 
     // decode a bech32 string, returning the "human-readable part" and a "data part"
-    static HrpAndDp decode(final String bstring) {
+    public static HrpAndDp decode(final String bstring) {
         Objects.requireNonNull(bstring);
 
-        Bech32.impl.rejectBStringThatIsntWellFormed(bstring);
-        HrpAndDp b = Bech32.impl.splitString(bstring);
-        Bech32.impl.rejectHRPTooShort(b.getHrp());
-        Bech32.impl.rejectHRPTooLong(b.getHrp());
-        Bech32.impl.rejectDPTooShort(b.getDp());
+        Impl.rejectBStringThatIsntWellFormed(bstring);
+        HrpAndDp b = Impl.splitString(bstring);
+        Impl.rejectHRPTooShort(b.getHrp());
+        Impl.rejectHRPTooLong(b.getHrp());
+        Impl.rejectDPTooShort(b.getDp());
         b.setHrp(b.getHrp().toLowerCase());
-        Bech32.impl.mapDP(b.getDp());
-        if (Bech32.impl.verifyChecksum(b.getHrp(), b.getDp())) {
-            b.setDp(Bech32.impl.stripChecksum(new String(b.getDp())).toCharArray());
+        Impl.mapDP(b.getDp());
+        if (Impl.verifyChecksum(b.getHrp(), b.getDp())) {
+            b.setDp(Impl.stripChecksum(new String(b.getDp())).toCharArray());
+            b.setEncoding(HrpAndDp.Encoding.BECH32M);
+            return b;
+        }
+        else if (Impl.verifyChecksumUsingOriginalConstant(b.getHrp(), b.getDp())) {
+            b.setDp(Impl.stripChecksum(new String(b.getDp())).toCharArray());
+            b.setEncoding(HrpAndDp.Encoding.BECH32);
             return b;
         }
         else {
-            throw new RuntimeException("bech32 string has bad checksum");
+            return new HrpAndDp();
         }
 
     }
 
-
+    private Bech32() {
+        throw new IllegalStateException("should not instantiate");
+    }
 }

--- a/src/main/java/design/contract/bech32/Bech32.java
+++ b/src/main/java/design/contract/bech32/Bech32.java
@@ -236,7 +236,7 @@ public class Bech32 {
     }
 
     // The Bech32 separator character
-    static final char SEPARATOR = '1';
+    public static final char SEPARATOR = '1';
 
     // exponent used in checksum generation, taken from recommendation
     // in: https://github.com/sipa/bips/blob/bip-bech32m/bip-bech32m.mediawiki

--- a/src/main/java/design/contract/bech32/HrpAndDp.java
+++ b/src/main/java/design/contract/bech32/HrpAndDp.java
@@ -6,10 +6,16 @@ import java.util.Objects;
 public class HrpAndDp {
     private String hrp;
     private char[] dp;
+    private Encoding encoding;
+
+    public HrpAndDp() {
+        this.encoding = Encoding.UNKNOWN;
+    }
 
     public HrpAndDp(String hrp, char[] dp) {
         this.hrp = hrp;
         this.dp = dp;
+        this.encoding = Encoding.UNKNOWN;
     }
 
     public String getHrp() {
@@ -28,6 +34,14 @@ public class HrpAndDp {
         this.dp = dp;
     }
 
+    public Encoding getEncoding() {
+        return encoding;
+    }
+
+    public void setEncoding(Encoding encoding) {
+        this.encoding = encoding;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o)
@@ -36,13 +50,18 @@ public class HrpAndDp {
             return false;
         HrpAndDp hrpAndDp = (HrpAndDp) o;
         return hrp.equals(hrpAndDp.hrp) &&
-                Arrays.equals(dp, hrpAndDp.dp);
+                Arrays.equals(dp, hrpAndDp.dp) &&
+                encoding == hrpAndDp.encoding;
     }
 
     @Override
     public int hashCode() {
-        int result = Objects.hash(hrp);
+        int result = Objects.hash(hrp, encoding);
         result = 31 * result + Arrays.hashCode(dp);
         return result;
+    }
+
+    public enum Encoding {
+        NONE, UNKNOWN, BECH32, BECH32M;
     }
 }

--- a/src/main/java/design/contract/example/Bech32DecodingExample.java
+++ b/src/main/java/design/contract/example/Bech32DecodingExample.java
@@ -14,6 +14,7 @@ public class Bech32DecodingExample {
 
         assert hd.getHrp().equals("hello");
         assert hd.getDp().length == 0;
+        assert hd.getEncoding() == HrpAndDp.Encoding.BECH32M;
     }
 
     private static void simpleHrp_WithData() {
@@ -30,6 +31,7 @@ public class Bech32DecodingExample {
         assert hd.getDp()[2] == 3;
         assert hd.getDp()[3] == 31;
         assert hd.getDp()[4] == 13;
+        assert hd.getEncoding() == HrpAndDp.Encoding.BECH32M;
     }
 
     public static void main(String[] args) {

--- a/src/main/java/design/contract/example/Bech32DecodingExample.java
+++ b/src/main/java/design/contract/example/Bech32DecodingExample.java
@@ -8,7 +8,7 @@ public class Bech32DecodingExample {
     private static void simpleHrp_WithoutData() {
         // this Bech32 string has human-readable part of "hello" and
         // no data part
-        String bString = "hello16s3sxm";
+        String bString = "hello1sn7ru8";
 
         HrpAndDp hd = Bech32.decode(bString);
 
@@ -19,7 +19,7 @@ public class Bech32DecodingExample {
     private static void simpleHrp_WithData() {
         // this Bech32 string has human-readable part of "hello" and
         // a data part which encodes to "w0rld"
-        String bString = "hello1w0rldcs7fw6";
+        String bString = "hello1w0rldjn365x";
 
         HrpAndDp hd = Bech32.decode(bString);
 

--- a/src/main/java/design/contract/example/Bech32EncodingExample.java
+++ b/src/main/java/design/contract/example/Bech32EncodingExample.java
@@ -11,8 +11,8 @@ public class Bech32EncodingExample {
         String b = Bech32.encode(humanReadablePart, data);
 
         System.out.println(b);
-        // prints "hello16s3sxm" :
-        //   "hello" + Bech32.separator ('1') + encoded data (none) + 6 char checksum ("6s3sxm")
+        // prints "hello1sn7ru8" :
+        //   "hello" + Bech32.SEPARATOR ('1') + encoded data (none) + 6 char checksum ("sn7ru8")
     }
 
     private static void simpleHrp_WithData() {
@@ -22,8 +22,8 @@ public class Bech32EncodingExample {
         String b = Bech32.encode(humanReadablePart, data);
 
         System.out.println(b);
-        // prints "hello1w0rldcs7fw6" :
-        //   "hello" + Bech32.separator ('1') + encoded data ("w0rld") + 6 char checksum ("cs7fw6")
+        // prints "hello1w0rldjn365x" :
+        //   "hello" + Bech32.SEPARATOR ('1') + encoded data ("w0rld") + 6 char checksum ("jn365x")
     }
 
     public static void main(String[] args) {

--- a/src/test/java/design/contract/bech32/Bech32Test.java
+++ b/src/test/java/design/contract/bech32/Bech32Test.java
@@ -4,6 +4,8 @@ import org.junit.Test;
 
 import java.util.Arrays;
 
+import static design.contract.bech32.HrpAndDp.Encoding.BECH32;
+import static design.contract.bech32.HrpAndDp.Encoding.BECH32M;
 import static org.junit.Assert.*;
 
 public class Bech32Test {
@@ -29,118 +31,118 @@ public class Bech32Test {
         assertEquals("tx1rjk0u5ng4jsfmc", Bech32.stripUnknownChars("tx1!rjk0\\u5ng*4jsf^^mc"));
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void rejectBStringTooShort_withShortString_throws() {
-        Bech32.impl.rejectBStringTooShort("ace");
+        Bech32.Impl.rejectBStringTooShort("ace");
     }
 
     @Test()
     public void rejectBStringTooShort_withLongString_wontThrow() {
-        Bech32.impl.rejectBStringTooShort("aceaceace");
+        Bech32.Impl.rejectBStringTooShort("aceaceace");
     }
 
     @Test()
     public void rejectBStringTooLong_withShortString_wontThrow() {
-        Bech32.impl.rejectBStringTooLong("aceaceace");
+        Bech32.Impl.rejectBStringTooLong("aceaceace");
     }
 
     @Test()
     public void rejectBStringTooLong_withLongerString_wontThrow() {
-        char[] buffer = new char[Bech32.limits.MAX_BECH32_LENGTH - 1];
+        char[] buffer = new char[Bech32.Limits.MAX_BECH32_LENGTH - 1];
         Arrays.fill(buffer, 'a');
-        Bech32.impl.rejectBStringTooLong(new String(buffer));
+        Bech32.Impl.rejectBStringTooLong(new String(buffer));
     }
 
     @Test()
     public void rejectBStringTooLong_withMaxLengthString_wontThrow() {
-        char[] buffer = new char[Bech32.limits.MAX_BECH32_LENGTH];
+        char[] buffer = new char[Bech32.Limits.MAX_BECH32_LENGTH];
         Arrays.fill(buffer, 'a');
-        Bech32.impl.rejectBStringTooLong(new String(buffer));
+        Bech32.Impl.rejectBStringTooLong(new String(buffer));
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void rejectBStringTooLong_withLongString_throws() {
-        char[] buffer = new char[Bech32.limits.MAX_BECH32_LENGTH + 1];
+        char[] buffer = new char[Bech32.Limits.MAX_BECH32_LENGTH + 1];
         Arrays.fill(buffer, 'a');
-        Bech32.impl.rejectBStringTooLong(new String(buffer));
+        Bech32.Impl.rejectBStringTooLong(new String(buffer));
     }
 
     @Test
     public void rejectBStringMixedCase_withSingleCaseString_wontThrow() {
-        Bech32.impl.rejectBStringMixedCase("abcdefg");
-        Bech32.impl.rejectBStringMixedCase("abc123def");
-        Bech32.impl.rejectBStringMixedCase("12AB34CD");
+        Bech32.Impl.rejectBStringMixedCase("abcdefg");
+        Bech32.Impl.rejectBStringMixedCase("abc123def");
+        Bech32.Impl.rejectBStringMixedCase("12AB34CD");
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void rejectBStringMixedCase_withMixedCases_throws() {
-        Bech32.impl.rejectBStringMixedCase("abcDefg");
+        Bech32.Impl.rejectBStringMixedCase("abcDefg");
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void rejectBStringMixedCase_withMixedCasesAndNumbers_throws() {
-        Bech32.impl.rejectBStringMixedCase("1abcDefg2");
+        Bech32.Impl.rejectBStringMixedCase("1abcDefg2");
     }
 
     @Test
     public void rejectBStringValuesOutOfRange_withInRangeStrings_wontThrow() {
-        Bech32.impl.rejectBStringValuesOutOfRange("abcde");
-        Bech32.impl.rejectBStringValuesOutOfRange("!!abcde}~");
+        Bech32.Impl.rejectBStringValuesOutOfRange("abcde");
+        Bech32.Impl.rejectBStringValuesOutOfRange("!!abcde}~");
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void rejectBStringValuesOutOfRange_withSpaces_throws() {
-        Bech32.impl.rejectBStringValuesOutOfRange("ab cd");
+        Bech32.Impl.rejectBStringValuesOutOfRange("ab cd");
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void rejectBStringValuesOutOfRange_withNonPrintable_throws() {
-        Bech32.impl.rejectBStringValuesOutOfRange("ab\ncd");
+        Bech32.Impl.rejectBStringValuesOutOfRange("ab\ncd");
     }
 
     @Test
     public void rejectBStringWithNoSeparator_withSeparator_wontThrow() {
-        Bech32.impl.rejectBStringWithNoSeparator("ab1cd");
+        Bech32.Impl.rejectBStringWithNoSeparator("ab1cd");
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void rejectBStringWithNoSeparator_withNoSeparator_throws() {
-        Bech32.impl.rejectBStringWithNoSeparator("abcd");
+        Bech32.Impl.rejectBStringWithNoSeparator("abcd");
     }
 
     @Test
     public void findSeparatorPosition_withSeparator() {
-        int pos = Bech32.impl.findSeparatorPosition("ab1cd");
+        int pos = Bech32.Impl.findSeparatorPosition("ab1cd");
         assertEquals(2, pos);
 
-        pos = Bech32.impl.findSeparatorPosition("abc1def1lalala");
+        pos = Bech32.Impl.findSeparatorPosition("abc1def1lalala");
         assertEquals(7, pos);
     }
 
     @Test
     public void findSeparatorPosition_withoutSeparator() {
-        int pos = Bech32.impl.findSeparatorPosition("");
+        int pos = Bech32.Impl.findSeparatorPosition("");
         assertEquals(-1, pos);
 
-        pos = Bech32.impl.findSeparatorPosition("lalalala");
+        pos = Bech32.Impl.findSeparatorPosition("lalalala");
         assertEquals(-1, pos);
     }
 
     @Test(expected = StringIndexOutOfBoundsException.class)
     public void splitString_withEmptyString_throws() {
-        HrpAndDp hd = Bech32.impl.splitString("");
+        HrpAndDp hd = Bech32.Impl.splitString("");
     }
 
     @Test
     public void splitString_withOnlySeparator_returnsEmptyStrings() {
-        HrpAndDp hd = Bech32.impl.splitString("1");
+        HrpAndDp hd = Bech32.Impl.splitString("1");
         assertEquals("", hd.getHrp());
         assertEquals(0, hd.getDp().length);
     }
 
     @Test
     public void splitString_withSeparatorAtStart_returnsOneString() {
-        HrpAndDp hd = Bech32.impl.splitString("1ab");
+        HrpAndDp hd = Bech32.Impl.splitString("1ab");
         assertEquals("", hd.getHrp());
         assertEquals(2, hd.getDp().length);
         assertEquals('a', hd.getDp()[0]);
@@ -149,14 +151,14 @@ public class Bech32Test {
 
     @Test
     public void splitString_withSeparatorAtEnd_returnsOneString() {
-        HrpAndDp hd = Bech32.impl.splitString("ab1");
+        HrpAndDp hd = Bech32.Impl.splitString("ab1");
         assertEquals("ab", hd.getHrp());
         assertEquals(0, hd.getDp().length);
     }
 
     @Test
     public void splitString_withSeparatorInMiddle_returnsTwoStrings() {
-        HrpAndDp hd = Bech32.impl.splitString("ab1cd");
+        HrpAndDp hd = Bech32.Impl.splitString("ab1cd");
         assertEquals("ab", hd.getHrp());
         assertEquals(2, hd.getDp().length);
         assertEquals('c', hd.getDp()[0]);
@@ -165,8 +167,8 @@ public class Bech32Test {
 
     @Test
     public void mapDP_withLowercaseData() {
-        HrpAndDp b = Bech32.impl.splitString("1acd");
-        Bech32.impl.mapDP(b.getDp());
+        HrpAndDp b = Bech32.Impl.splitString("1acd");
+        Bech32.Impl.mapDP(b.getDp());
         assertEquals(0x001d, b.getDp()[0]);
         assertEquals(0x0018, b.getDp()[1]);
         assertEquals(0x000d, b.getDp()[2]);
@@ -174,22 +176,22 @@ public class Bech32Test {
 
     @Test
     public void mapDP_withUppercaseData() {
-        HrpAndDp b = Bech32.impl.splitString("1ACD");
-        Bech32.impl.mapDP(b.getDp());
+        HrpAndDp b = Bech32.Impl.splitString("1ACD");
+        Bech32.Impl.mapDP(b.getDp());
         assertEquals(0x001d, b.getDp()[0]);
         assertEquals(0x0018, b.getDp()[1]);
         assertEquals(0x000d, b.getDp()[2]);
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void mapDP_withInvalidData_throws() {
-        HrpAndDp b = Bech32.impl.splitString("1abc"); // 'b' is invalid
-        Bech32.impl.mapDP(b.getDp());
+        HrpAndDp b = Bech32.Impl.splitString("1abc"); // 'b' is invalid
+        Bech32.Impl.mapDP(b.getDp());
     }
 
     @Test
     public void expandHrp_withUppercaseHrp() {
-        String e = Bech32.impl.expandHrp("ABC");
+        String e = Bech32.Impl.expandHrp("ABC");
         assertEquals(0x0002, e.charAt(0));
         assertEquals(0x0002, e.charAt(1));
         assertEquals(0x0002, e.charAt(2));
@@ -201,7 +203,7 @@ public class Bech32Test {
 
     @Test
     public void expandHrp_withLowercaseHrp() {
-        String e = Bech32.impl.expandHrp("abc");
+        String e = Bech32.Impl.expandHrp("abc");
         assertEquals(0x0003, e.charAt(0));
         assertEquals(0x0003, e.charAt(1));
         assertEquals(0x0003, e.charAt(2));
@@ -213,61 +215,75 @@ public class Bech32Test {
 
     @Test
     public void polymod_short() {
-        String e = Bech32.impl.expandHrp("A");
-        long p = Bech32.impl.polymod(e.toCharArray());
+        String e = Bech32.Impl.expandHrp("A");
+        long p = Bech32.Impl.polymod(e.toCharArray());
         assertEquals(34817, p);
     }
 
     @Test
     public void polymod_long() {
-        String e = Bech32.impl.expandHrp("qwerty");
-        long p = Bech32.impl.polymod(e.toCharArray());
+        String e = Bech32.Impl.expandHrp("qwerty");
+        long p = Bech32.Impl.polymod(e.toCharArray());
         assertEquals(448484437, p);
     }
 
     @Test
     public void verifyChecksum_withShortHrp_noData_isGood() {
-        HrpAndDp b = Bech32.impl.splitString("a14rxqtp");
-        Bech32.impl.mapDP(b.getDp());
-        assertTrue(Bech32.impl.verifyChecksum(b.getHrp(), b.getDp()));
+        HrpAndDp b = Bech32.Impl.splitString("a1lqfn3a");
+        Bech32.Impl.mapDP(b.getDp());
+        assertTrue(Bech32.Impl.verifyChecksum(b.getHrp(), b.getDp()));
+    }
+
+    @Test
+    public void verifyChecksum_c1_withShortHrp_noData_isGood() {
+        HrpAndDp b = Bech32.Impl.splitString("a12uel5l");
+        Bech32.Impl.mapDP(b.getDp());
+        assertTrue(Bech32.Impl.verifyChecksumUsingOriginalConstant(b.getHrp(), b.getDp()));
     }
 
     @Test
     public void verifyChecksum_withLongerHrp_longData_isGood() {
-        HrpAndDp b = Bech32.impl.splitString("abcdef1qpzry9x8gf2tvdw0s3jn54khce6mua7lyllles");
-        Bech32.impl.mapDP(b.getDp());
-        assertTrue(Bech32.impl.verifyChecksum(b.getHrp(), b.getDp()));
+        HrpAndDp b = Bech32.Impl.splitString("abcdef1l7aum6echk45nj3s0wdvt2fg8x9yrzpqzd3ryx");
+        Bech32.Impl.mapDP(b.getDp());
+        assertTrue(Bech32.Impl.verifyChecksum(b.getHrp(), b.getDp()));
+    }
+
+    @Test
+    public void verifyChecksum_c1_withLongerHrp_longData_isGood() {
+        HrpAndDp b = Bech32.Impl.splitString("abcdef1qpzry9x8gf2tvdw0s3jn54khce6mua7lmqqqxw");
+        Bech32.Impl.mapDP(b.getDp());
+        assertTrue(Bech32.Impl.verifyChecksumUsingOriginalConstant(b.getHrp(), b.getDp()));
     }
 
     @Test
     public void verifyChecksum_withShortHrp_noData_isBad() {
         // this is "bad" because one character from above is changed
-        HrpAndDp b = Bech32.impl.splitString("b12uel5l");
-        Bech32.impl.mapDP(b.getDp());
-        assertFalse(Bech32.impl.verifyChecksum(b.getHrp(), b.getDp()));
+        HrpAndDp b = Bech32.Impl.splitString("b12uel5l");
+        Bech32.Impl.mapDP(b.getDp());
+        assertFalse(Bech32.Impl.verifyChecksum(b.getHrp(), b.getDp()));
     }
 
     @Test
     public void verifyChecksum_withLongerHrp_longData_isBad() {
         // this is "bad" because one character from above is changed
-        HrpAndDp b = Bech32.impl.splitString("abcdeg1qpzry9x8gf2tvdw0s3jn54khce6mua7lmqqqxw");
-        Bech32.impl.mapDP(b.getDp());
-        assertFalse(Bech32.impl.verifyChecksum(b.getHrp(), b.getDp()));
+        HrpAndDp b = Bech32.Impl.splitString("abcdeg1qpzry9x8gf2tvdw0s3jn54khce6mua7lmqqqxw");
+        Bech32.Impl.mapDP(b.getDp());
+        assertFalse(Bech32.Impl.verifyChecksum(b.getHrp(), b.getDp()));
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test(expected = StringIndexOutOfBoundsException.class)
     public void stripChecksum_inputTooSmall_throws() {
-        Bech32.impl.stripChecksum("abcde");
+        Bech32.Impl.stripChecksum("abcde");
     }
 
     @Test
     public void stripChecksum_inputOnlyChecksum_returnsEmptyString() {
-        assertEquals(0, Bech32.impl.stripChecksum("abcdef").length());
+        assertEquals(0, Bech32.Impl.stripChecksum("abcdef").length());
     }
 
     @Test
     public void stripChecksum_inputIsLonger_returnsStringWithoutChecksum() {
-        String shortened = Bech32.impl.stripChecksum("helloabcdef");
+        String shortened = Bech32.Impl.stripChecksum("helloabcdef");
         assertEquals("hello", shortened);
     }
 
@@ -275,17 +291,30 @@ public class Bech32Test {
     public void createChecksum_simple() {
         String hrp = "a";
         char[] data = new char[0];
-        char[] checksum = Bech32.impl.createChecksum(hrp, data).toCharArray();
-        assertEquals(0x0015, checksum[0]);
-        assertEquals(0x0003, checksum[1]);
-        assertEquals(0x0006, checksum[2]);
-        assertEquals(0x0000, checksum[3]);
-        assertEquals(0x000b, checksum[4]);
-        assertEquals(0x0001, checksum[5]);
+        char[] checksum = Bech32.Impl.createChecksum(hrp, data).toCharArray();
+        assertEquals(0x001f, checksum[0]);
+        assertEquals(0x0000, checksum[1]);
+        assertEquals(0x0009, checksum[2]);
+        assertEquals(0x0013, checksum[3]);
+        assertEquals(0x0011, checksum[4]);
+        assertEquals(0x001d, checksum[5]);
+    }
+
+    @Test
+    public void createChecksum_c1_simple() {
+        String hrp = "a";
+        char[] data = new char[0];
+        char[] checksum = Bech32.Impl.createChecksumUsingOriginalConstant(hrp, data).toCharArray();
+        assertEquals(0x000a, checksum[0]);
+        assertEquals(0x001c, checksum[1]);
+        assertEquals(0x0019, checksum[2]);
+        assertEquals(0x001f, checksum[3]);
+        assertEquals(0x0014, checksum[4]);
+        assertEquals(0x001f, checksum[5]);
     }
 
 
-    @Test(expected = RuntimeException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void encode_emptyArgs_throws() {
         String hrp = "";
         char[] data = new char[0];
@@ -297,15 +326,23 @@ public class Bech32Test {
         String hrp = "a";
         char[] data = new char[0];
         String b = Bech32.encode(hrp, data);
-        assertEquals("a14rxqtp", b);
+        assertEquals("a1lqfn3a", b);
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test
+    public void encode_c1_simple() {
+        String hrp = "a";
+        char[] data = new char[0];
+        String b = Bech32.encodeUsingOriginalConstant(hrp, data);
+        assertEquals("a12uel5l", b);
+    }
+
+    @Test(expected = NullPointerException.class)
     public void decode_nullString_throws() {
         HrpAndDp hd = Bech32.decode(null);
     }
 
-    @Test(expected = RuntimeException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void decode_emptyString_throws() {
         HrpAndDp hd = Bech32.decode("");
     }
@@ -314,7 +351,7 @@ public class Bech32Test {
     public void decode_stringTooShort_throws() {
         try {
             HrpAndDp hd = Bech32.decode("a");
-        } catch(RuntimeException e) {
+        } catch(IllegalArgumentException e) {
             assertEquals("bech32 string too short", e.getMessage());
         }
     }
@@ -323,7 +360,7 @@ public class Bech32Test {
     public void decode_stringTooLong_throws() {
         try {
             HrpAndDp hd = Bech32.decode("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
-        } catch(RuntimeException e) {
+        } catch(IllegalArgumentException e) {
             assertEquals("bech32 string too long", e.getMessage());
         }
     }
@@ -332,7 +369,7 @@ public class Bech32Test {
     public void decode_stringMixedCase_throws() {
         try {
             HrpAndDp hd = Bech32.decode("aAaaaaaaaaaaaaaaaa");
-        } catch(RuntimeException e) {
+        } catch(IllegalArgumentException e) {
             assertEquals("bech32 string is mixed case", e.getMessage());
         }
     }
@@ -341,14 +378,14 @@ public class Bech32Test {
     public void decode_stringValuesOutOfRange_throws() {
         try {
             HrpAndDp hd = Bech32.decode("a aaaaaaaaaaaaaaaa");
-        } catch(RuntimeException e) {
+        } catch(IllegalArgumentException e) {
             assertEquals("bech32 string has value out of range", e.getMessage());
         }
         try {
             String s = "aaaa" + '\u0127' + "aaaa";
 
             HrpAndDp hd = Bech32.decode(s);
-        } catch(RuntimeException e) {
+        } catch(IllegalArgumentException e) {
             assertEquals("bech32 string has value out of range", e.getMessage());
         }
     }
@@ -357,7 +394,7 @@ public class Bech32Test {
     public void decode_stringNoSeparator_throws() {
         try {
             HrpAndDp hd = Bech32.decode("aaaaaaaaaaaaaaaaaaaaaaaaaaaa");
-        } catch(RuntimeException e) {
+        } catch(IllegalArgumentException e) {
             assertEquals("bech32 string is missing separator character", e.getMessage());
         }
     }
@@ -366,7 +403,7 @@ public class Bech32Test {
     public void decode_stringHrpTooShort_throws() {
         try {
             HrpAndDp hd = Bech32.decode("1aaaaaaaaaaaaaaaaaaaaaaaaaaaa");
-        } catch(RuntimeException e) {
+        } catch(IllegalArgumentException e) {
             assertEquals("HRP must be at least one character", e.getMessage());
         }
     }
@@ -375,7 +412,7 @@ public class Bech32Test {
     public void decode_stringHrpTooLong_throws() {
         try {
             HrpAndDp hd = Bech32.decode("an84characterlonghumanreadablepartaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1a");
-        } catch(RuntimeException e) {
+        } catch(IllegalArgumentException e) {
             assertEquals("HRP must be less than 84 characters", e.getMessage());
         }
     }
@@ -384,7 +421,7 @@ public class Bech32Test {
     public void decode_stringDataPartTooShort_throws() {
         try {
             HrpAndDp hd = Bech32.decode("a33characterlonghumanreadablepart1a");
-        } catch(RuntimeException e) {
+        } catch(IllegalArgumentException e) {
             assertEquals("data part must be at least six characters", e.getMessage());
         }
     }
@@ -393,49 +430,88 @@ public class Bech32Test {
     public void decode_badChecksum_throws() {
         try {
             HrpAndDp hd = Bech32.decode("a12uel5m");
-        } catch(RuntimeException e) {
+        } catch(IllegalArgumentException e) {
             assertEquals("bech32 string has bad checksum", e.getMessage());
         }
     }
 
     @Test
     public void decode_simple() {
-        HrpAndDp hd = Bech32.decode("a14rxqtp");
+        HrpAndDp hd = Bech32.decode("a1lqfn3a");
         assertEquals("a", hd.getHrp());
         assertEquals(0, hd.getDp().length);
+        assertEquals(BECH32M, hd.getEncoding());
+    }
+
+    @Test
+    public void decode_c1_simple() {
+        HrpAndDp hd = Bech32.decode("a12uel5l");
+        assertEquals("a", hd.getHrp());
+        assertEquals(0, hd.getDp().length);
+        assertEquals(BECH32, hd.getEncoding());
     }
 
     @Test
     public void decode_longer() {
-        HrpAndDp hd = Bech32.decode("abcdef1qpzry9x8gf2tvdw0s3jn54khce6mua7lyllles");
+        HrpAndDp hd = Bech32.decode("abcdef1l7aum6echk45nj3s0wdvt2fg8x9yrzpqzd3ryx");
         assertEquals("abcdef", hd.getHrp());
         assertEquals(32, hd.getDp().length);
-        assertEquals(0x0000, hd.getDp()[0]); // 'q' in above data part
-        assertEquals(0x001f, hd.getDp()[31]);// 'l' in above data part
+        assertEquals(0x001f, hd.getDp()[0]); // first 'l' in above data part
+        assertEquals(0x0000, hd.getDp()[31]);// last 'q' in above data part
+        assertEquals(BECH32M, hd.getEncoding());
     }
 
     @Test
-    public void decodeThenEncode_givesInitialData_1() {
-        String bstr = "abcdef1qpzry9x8gf2tvdw0s3jn54khce6mua7lyllles";
+    public void decode_c1_longer() {
+        HrpAndDp hd = Bech32.decode("abcdef1qpzry9x8gf2tvdw0s3jn54khce6mua7lmqqqxw");
+        assertEquals("abcdef", hd.getHrp());
+        assertEquals(32, hd.getDp().length);
+        assertEquals(0x0000, hd.getDp()[0]); // first 'q' in above data part
+        assertEquals(0x001f, hd.getDp()[31]);// last 'l' in above data part
+        assertEquals(BECH32, hd.getEncoding());
+    }
+
+    @Test
+    public void decodeThenEncode_givesInitialData_long() {
+        String bstr = "abcdef1l7aum6echk45nj3s0wdvt2fg8x9yrzpqzd3ryx";
 
         HrpAndDp hd = Bech32.decode(bstr);
         assertEquals("abcdef", hd.getHrp());
 
         String enc = Bech32.encode(hd.getHrp(), hd.getDp());
         assertEquals(bstr, enc);
-
     }
 
     @Test
-    public void decodeThenEncode_givesInitialData_2() {
-        String bstr = "split1checkupstagehandshakeupstreamerranterredcaperred4m6xws";
+    public void decodeThenEncode_c1_givesInitialData_long() {
+        String bstr = "abcdef1qpzry9x8gf2tvdw0s3jn54khce6mua7lmqqqxw";
+
+        HrpAndDp hd = Bech32.decode(bstr);
+        assertEquals("abcdef", hd.getHrp());
+
+        String enc = Bech32.encodeUsingOriginalConstant(hd.getHrp(), hd.getDp());
+        assertEquals(bstr, enc);
+    }
+
+    @Test
+    public void decodeThenEncode_givesInitialData_longer() {
+        String bstr = "split1checkupstagehandshakeupstreamerranterredcaperredlc445v";
 
         HrpAndDp hd = Bech32.decode(bstr);
         assertEquals("split", hd.getHrp());
 
         String enc = Bech32.encode(hd.getHrp(), hd.getDp());
         assertEquals(bstr, enc);
+    }
+    @Test
+    public void decodeThenEncode_c1_givesInitialData_longer() {
+        String bstr = "split1checkupstagehandshakeupstreamerranterredcaperred2y9e3w";
 
+        HrpAndDp hd = Bech32.decode(bstr);
+        assertEquals("split", hd.getHrp());
+
+        String enc = Bech32.encodeUsingOriginalConstant(hd.getHrp(), hd.getDp());
+        assertEquals(bstr, enc);
     }
 
 }

--- a/src/test/java/design/contract/bech32/HrpAndDpTest.java
+++ b/src/test/java/design/contract/bech32/HrpAndDpTest.java
@@ -37,6 +37,21 @@ public class HrpAndDpTest {
     }
 
     @Test
+    public void getEncoding() {
+        HrpAndDp.Encoding expected = HrpAndDp.Encoding.UNKNOWN;
+        HrpAndDp hrpAndDp = new HrpAndDp("hello", null);
+        assertEquals(expected, hrpAndDp.getEncoding());
+    }
+
+    @Test
+    public void setEncoding() {
+        HrpAndDp.Encoding expected = HrpAndDp.Encoding.BECH32M;
+        HrpAndDp hrpAndDp = new HrpAndDp("hello", null);
+        hrpAndDp.setEncoding(HrpAndDp.Encoding.BECH32M);
+        assertEquals(expected, hrpAndDp.getEncoding());
+    }
+
+    @Test
     public void testEquals_Reflexive() {
         char[] dp = {0,1,2};
         HrpAndDp a = new HrpAndDp("a", dp);


### PR DESCRIPTION
This PR contains all changes needed to update the bech32 algorithm's exponential constant from the original value of "1", then the intermediate value of "0x3FFFFFFF", to the now final value of "0x2bc830a3". This final value, also known as "M", was decided upon following the recent research by Pieter Wuille, currently seen here: https://github.com/sipa/bips/blob/bip-bech32m/bip-bech32m.mediawiki

Some items to consider (similar to the c++ library): HrpAndDp is a crappy struct name for the decoded "human readable" and "data" parts. Can you suggest something better? I'm also not terribly fond of the function name "encodeUsingOriginalConstant()" which goes along with the default of "encode()".
